### PR TITLE
adición: funcionalidad de registrar personal

### DIFF
--- a/gest-ashoex-backend/app/Http/Controllers/PersonalAcademicoController.php
+++ b/gest-ashoex-backend/app/Http/Controllers/PersonalAcademicoController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\PersonalAcademico;
+use Illuminate\Http\Request;
+
+class PersonalAcademicoController extends Controller
+{
+    public function registrar(Request $request)
+    {
+        $personalAcademico = PersonalAcademico::create([
+            'name' => $request->name,
+            'email' => $request->email,
+            'telefono' => $request->telefono,
+            'estado' => $request->estado,
+            'tipo_personal_id' => $request->tipo_personal_id,
+        ]);
+
+        return response()->json([
+            'message' => 'Personal académico registrado exitosamente',
+            'personalAcademico' => $personalAcademico
+        ], 201);
+    }
+}

--- a/gest-ashoex-backend/app/Models/PersonalAcademico.php
+++ b/gest-ashoex-backend/app/Models/PersonalAcademico.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PersonalAcademico extends Model
+{
+    use HasFactory;
+
+    protected $table = 'personal_academicos';
+
+    protected $fillable = [
+        'name',
+        'email',
+        'telefono',
+        'estado',
+        'tipo_personal_id',
+    ];
+
+    public function tipoPersonal()
+    {
+        return $this->belongsTo(TipoPersonal::class, 'tipo_personal_id');
+    }
+}

--- a/gest-ashoex-backend/database/migrations/2024_09_28_134906_create_tipo_personals_table.php
+++ b/gest-ashoex-backend/database/migrations/2024_09_28_134906_create_tipo_personals_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tipo_personals', function (Blueprint $table) {
+            $table->id();
+            $table->string('nombre');
+            $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tipo_personals');
+    }
+};

--- a/gest-ashoex-backend/database/migrations/2024_09_28_134927_personal_academico_log.php
+++ b/gest-ashoex-backend/database/migrations/2024_09_28_134927_personal_academico_log.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_academico_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique(); // include a regex. 
+            $table->string('telefono'); // include a simple domain. 
+            $table->string('estado'); // include a simple domain.
+            $table->string('tipo_personal');
+
+            $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+        }); 
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_academico_logs');
+    }
+};

--- a/gest-ashoex-backend/database/migrations/2024_09_28_350245_create_personal_academicos_table.php
+++ b/gest-ashoex-backend/database/migrations/2024_09_28_350245_create_personal_academicos_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_academicos', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique()->domain('/^[a-zA-Z0-9.!#$%&\'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/');
+            $table->string('telefono'); // include a simple domain. 
+            $table->string('estado'); // include a simple domain.
+
+            $table->unsignedInteger('tipo_personal_id'); 
+
+            $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+
+            $table->foreign('tipo_personal_id')
+                ->references('id')
+                ->on('tipo_personals')
+                ->cascadeOnDelete();
+        }); 
+
+        // add a trigger. 
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_academicos');
+    }
+};

--- a/gest-ashoex-backend/routes/api.php
+++ b/gest-ashoex-backend/routes/api.php
@@ -3,5 +3,8 @@
 use Illuminate\Support\Facades\Route;
 
 use App\Http\Controllers\HealthController;
+use App\Http\Controllers\PersonalAcademicoController;
 
 Route::get('/health', [HealthController::class, 'check']);
+
+Route::post('/registrar-personal-academico', [PersonalAcademicoController::class, 'registrar']);

--- a/gest-ashoex-frontend/src/App.jsx
+++ b/gest-ashoex-frontend/src/App.jsx
@@ -1,12 +1,15 @@
 import { useState } from 'react'
 import HealthCheck from './components/health/health.jsx'
 import './App.css'
+import RegistrarPersonalPage from './pages/registrar_personal_page.jsx';
+
 
 function App() {
 
   return (
     <>
     <HealthCheck />
+    <RegistrarPersonalPage />
     </>
   )
 }

--- a/gest-ashoex-frontend/src/components/registrar_personal_form/registrar_personal_form.css
+++ b/gest-ashoex-frontend/src/components/registrar_personal_form/registrar_personal_form.css
@@ -1,0 +1,57 @@
+.form {
+    max-width: 400px;
+    margin: 0 auto;
+    padding: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
+  }
+  
+  .form-group {
+    margin-bottom: 1rem;
+  }
+  
+  .form-group label {
+    display: block;
+    margin-bottom: 0.5rem;
+  }
+  
+  .form-group input {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
+  }
+  
+  .form-group select {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
+  }
+  
+  .form-group select {
+    appearance: none;
+    background-color: #fff;
+    background-image: url('data:image/svg+xml;charset=US-ASCII,<svg xmlns="http://www.w3.org/2000/svg" width="4" height="5" viewBox="0 0 4 5"><path fill="%23000" d="M2 0L0 2h4L2 0zM2 5L0 3h4L2 5z"/></svg>');
+    background-repeat: no-repeat;
+    background-position: right 0.5rem center;
+    background-size: 0.65rem auto;
+  }
+  
+
+  button {
+    width: 100%;
+    padding: 0.75rem;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  
+  button:hover {
+    background-color: #0056b3;
+  }

--- a/gest-ashoex-frontend/src/components/registrar_personal_form/registrar_personal_form.jsx
+++ b/gest-ashoex-frontend/src/components/registrar_personal_form/registrar_personal_form.jsx
@@ -1,0 +1,82 @@
+import React, { useState } from "react";
+import "./registrar_personal_form.css";
+import { registrarPersonal } from "../../services/registrar_personal_api";
+
+const RegistrarPersonalForm = () => {
+  const [formData, setFormData] = useState({
+    name: "",
+    email: "",
+    telefono: "",
+    tipo_personal_id: "",
+    estado: "activo",
+  });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData({
+      ...formData,
+      [name]: value,
+    });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const response = await registrarPersonal(formData);
+      console.log("Datos del formulario:", response);
+    } catch (error) {
+      console.error("Error al registrar personal:", error);
+    }
+  };
+
+  return (
+    <form className="form" onSubmit={handleSubmit}>
+      <div className="form-group">
+        <label htmlFor="name">Nombre:</label>
+        <input
+          type="text"
+          id="name"
+          name="name"
+          value={formData.name}
+          onChange={handleChange}
+        />
+      </div>
+      <div className="form-group">
+        <label htmlFor="email">Email:</label>
+        <input
+          type="email"
+          id="email"
+          name="email"
+          value={formData.email}
+          onChange={handleChange}
+        />
+      </div>
+      <div className="form-group">
+        <label htmlFor="telefono">Teléfono:</label>
+        <input
+          type="tel"
+          id="telefono"
+          name="telefono"
+          value={formData.telefono}
+          onChange={handleChange}
+        />
+      </div>
+      <div className="form-group">
+        <label htmlFor="tipo_personal_id">Rol:</label>
+        <select
+          id="tipo_personal_id"
+          name="tipo_personal_id"
+          value={formData.tipo_personal_id}
+          onChange={handleChange}
+        >
+          <option value="">Seleccione un rol</option>
+          <option value="1">Docente</option>
+          <option value="2">Auxiliar</option>
+        </select>
+      </div>
+      <button type="submit">Registrar</button>
+    </form>
+  );
+};
+
+export default RegistrarPersonalForm;

--- a/gest-ashoex-frontend/src/pages/registrar_personal_page.jsx
+++ b/gest-ashoex-frontend/src/pages/registrar_personal_page.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import RegistrarPersonalForm from '../components/registrar_personal_form/registrar_personal_form.jsx';
+
+const RegistrarPersonalPage = () => {
+  return (
+    <div>
+      <h1>Registro de Personal</h1>
+      <RegistrarPersonalForm />
+    </div>
+  );
+};
+
+export default RegistrarPersonalPage;

--- a/gest-ashoex-frontend/src/services/registrar_personal_api.js
+++ b/gest-ashoex-frontend/src/services/registrar_personal_api.js
@@ -1,0 +1,24 @@
+ // URL de API de prueba, remplazar por la URL de la API real
+const API_URL = 'http://127.0.0.1:8000/api/';
+
+export const registrarPersonal = async (formData) => {
+  try {
+    const response = await fetch(`${API_URL}/registrar-personal-academico`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(formData),
+    });
+
+    if (!response.ok) {
+      throw new Error('Error en la solicitud');
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error('Error registrando personal:', error);
+    throw error;
+  }
+};


### PR DESCRIPTION
¿Qué es lo nuevo?
    Se creo el Modelo y el Controlador de Personal Académico con la función de registrar, ademas del endpoint para realizar el registro.
    Los archivos nuevo son:
        - PersonalAcademico.php
        - PersonalAcademicoController.php
- ¿Cómo se prueba?
    Para probar se debe utilizar Thunder Client, Postman o similares. De forma local se puede hacer de la siguiente forma:
    Método POST: http://127.0.0.1:8000/api/registrar-personal-academico
    Y enviar un JSON con los datos del personal académico:
    
    Ejm: 
            {
              "name": "Juan Perez",
              "email": "juan.p@example.com",
              "telefono": "444444444",
              "tipo_personal_id": 1,
              "estado": "activo"
            } 
    Para que se registre el personal es necesario tener guardado en nuestra base de datos al menos un "tipo de personal" de otra forma habrá un error al no existir tipo_personal_id valido.


- Problemas conocidos
Sin problemas conocidos.
