### PR TITLE
Modificar personal academico

### DIFF
--- a/gest-ashoex-backend/app/Http/Controllers/PersonalAcademicoController.php
+++ b/gest-ashoex-backend/app/Http/Controllers/PersonalAcademicoController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\PersonalAcademico;
+use Illuminate\Http\Request;
+
+class PersonalAcademicoController extends Controller
+{
+
+    public function update(Request $request, $id)
+    {
+
+        $personalAcademico = PersonalAcademico::find($id);
+
+        if (!$personalAcademico) {
+            return response()->json([
+                'message' => 'Personal académico no encontrado.'
+            ], 404);
+        }
+
+        $personalAcademico->name = $request->input('name');
+        $personalAcademico->email = $request->input('email');
+        $personalAcademico->telefono = $request->input('telefono');
+        $personalAcademico->estado = $request->input('estado');
+        $personalAcademico->tipo_personal_id = $request->input('tipo_personal_id');
+
+        $personalAcademico->save();
+
+        return response()->json([
+            'message' => 'Personal académico actualizado exitosamente.',
+            'personal_academico' => $personalAcademico
+        ], 200);
+    }
+
+}

--- a/gest-ashoex-backend/routes/api.php
+++ b/gest-ashoex-backend/routes/api.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Http\Controllers\PersonalAcademicoController;
 use Illuminate\Support\Facades\Route;
 
 use App\Http\Controllers\HealthController;
 
 Route::get('/health', [HealthController::class, 'check']);
+
+Route::put('/personal-academico/{id}', [PersonalAcademicoController::class,'update']);

--- a/gest-ashoex-frontend/package-lock.json
+++ b/gest-ashoex-frontend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "axios": "^1.7.7",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.26.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
@@ -928,6 +929,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.2.tgz",
+      "integrity": "sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3541,6 +3551,38 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.2.tgz",
+      "integrity": "sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.19.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.2.tgz",
+      "integrity": "sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.19.2",
+        "react-router": "6.26.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/gest-ashoex-frontend/package-lock.json
+++ b/gest-ashoex-frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "gest-ashoex-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.7.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1428,6 +1429,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -1441,6 +1448,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1567,6 +1585,18 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1706,6 +1736,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/doctrine": {
@@ -2298,6 +2337,26 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -2305,6 +2364,20 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fsevents": {
@@ -3085,6 +3158,27 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3375,6 +3469,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/gest-ashoex-frontend/package.json
+++ b/gest-ashoex-frontend/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "axios": "^1.7.7",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/gest-ashoex-frontend/package.json
+++ b/gest-ashoex-frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.7.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/gest-ashoex-frontend/src/App.jsx
+++ b/gest-ashoex-frontend/src/App.jsx
@@ -1,18 +1,21 @@
 import { useState } from 'react'
 import HealthCheck from './components/health/health.jsx'
-
 import './App.css'
-import React from 'react';
-import ActualizarPersonal from './components/modificar/ActualizarPersonal.jsx';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+
+import ActualizarPersonalPage from './pages/ActualizarPersonalPage.jsx';
+
 function App() {
 
   return (
-    // <>
-    // <HealthCheck />
-    // </>
-    <div className="App">
-    <ActualizarPersonal />
-    </div>
+    <>
+    <Router>
+      <Routes>
+        <Route path='/' element={<HealthCheck/>} />
+        <Route path='/modificar-personal' element={<ActualizarPersonalPage />} />
+      </Routes>
+    </Router>
+    </>
  )
 }
 

--- a/gest-ashoex-frontend/src/App.jsx
+++ b/gest-ashoex-frontend/src/App.jsx
@@ -1,14 +1,20 @@
 import { useState } from 'react'
 import HealthCheck from './components/health/health.jsx'
-import './App.css'
 
+import './App.css'
+import React from 'react';
+import ActualizarPersonal from './components/modificar/ActualizarPersonal.jsx';
 function App() {
 
   return (
-    <>
-    <HealthCheck />
-    </>
-  )
+    // <>
+    // <HealthCheck />
+    // </>
+    <div className="App">
+    <ActualizarPersonal />
+    </div>
+ )
 }
 
 export default App
+

--- a/gest-ashoex-frontend/src/components/modificar/ActualizarPersonal.css
+++ b/gest-ashoex-frontend/src/components/modificar/ActualizarPersonal.css
@@ -1,0 +1,53 @@
+html, body {
+    height: 100%; /* Asegura que el body ocupe toda la altura de la ventana */
+    margin: 0; /* Elimina el margen predeterminado */
+    display: flex; /* Usa Flexbox para centrar */
+    justify-content: center; /* Centra horizontalmente */
+    align-items: center; /* Centra verticalmente */
+    background-color: #f4f4f4; /* Color de fondo */
+    font-family: Arial, sans-serif;
+}
+
+.container {
+    max-width: 600px; /* Ancho máximo del contenedor */
+    width: 100%; /* Asegura que el contenedor se ajuste a dispositivos más pequeños */
+    background: #fff; /* Fondo blanco */
+    padding: 20px; /* Espaciado interno */
+    border-radius: 8px; /* Bordes redondeados */
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1); /* Sombra */
+}
+
+h1 {
+    text-align: center; /* Centra el texto del encabezado */
+    margin-bottom: 20px; /* Espacio inferior */
+}
+
+.form-group {
+    margin-bottom: 15px; /* Espacio entre grupos de inputs */
+}
+
+.form-group label {
+    display: block; /* Asegura que el label ocupe todo el ancho */
+    margin-bottom: 5px; /* Espacio entre el label y el input */
+    text-align: left; /* Alinear el texto del label a la izquierda */
+}
+
+.form-group input {
+    width: calc(100% - 20px); /* Ajuste del ancho para padding */
+    padding: 10px; /* Espaciado interno del input */
+    border: 1px solid #ccc; /* Borde */
+    border-radius: 4px; /* Bordes redondeados */
+}
+
+.btn {
+    padding: 10px 15px; /* Espaciado interno del botón */
+    background-color: #007bff; /* Color de fondo del botón */
+    color: #fff; /* Color del texto */
+    border: none; /* Sin borde */
+    border-radius: 4px; /* Bordes redondeados */
+    cursor: pointer; /* Cambia el cursor al pasar el mouse */
+}
+
+.btn:hover {
+    background-color: #0056b3; /* Color de fondo al pasar el mouse */
+}

--- a/gest-ashoex-frontend/src/components/modificar/ActualizarPersonal.jsx
+++ b/gest-ashoex-frontend/src/components/modificar/ActualizarPersonal.jsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import './ActualizarPersonal.css'; // Importa la hoja de estilos
+import fetchHealthStatus from '../../services/healthService.js';
+
+function ActualizarPersonal() {
+  // Estados para almacenar los datos del formulario
+  const [id, setId] = useState('');
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [telefono, setTelefono] = useState('');
+  const [estado, setEstado] = useState('');
+  const [tipoPersonalId, setTipoPersonalId] = useState('');
+  const [mensaje, setMensaje] = useState('');
+
+  // Función para manejar el envío del formulario
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    // Crear un objeto con los datos del formulario
+    const personalData = {
+      name: name,
+      email: email,
+      telefono: telefono,
+      estado: estado,
+      tipo_personal_id: tipoPersonalId,
+    };
+
+    // Hacer la solicitud PUT a la API de Laravel
+    axios
+      .put(`http://127.0.0.1:8000/api/personal-academico/${id}`, personalData)
+      .then((response) => {
+        setMensaje('Personal académico actualizado exitosamente.');
+        console.log('Respuesta del servidor:', response.data);
+      })
+      .catch((error) => {
+        setMensaje('Hubo un error al actualizar el personal académico.');
+        console.error('Error al hacer la solicitud:', error);
+      });
+  };
+
+  return (
+    <div class="container">
+    <h1>Actualizar Personal Académico</h1>
+    <form id="personal-form" onSubmit={handleSubmit}>
+        <div class="form-group">
+            <label for="id">ID:</label>
+            <input  type="text"
+                    value={id}
+                    onChange={(e) => setId(e.target.value)}
+                    required
+                    placeholder="ID del personal"/>
+        </div>
+        <div class="form-group">
+            <label for="name">Nombre:</label>
+            <input  type="text"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    required
+                    placeholder="Nombre" />
+        </div>
+        <div class="form-group">
+            <label for="email">Email:</label>
+            <input  type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    placeholder="Correo electrónico" />
+        </div>
+        <div class="form-group">
+            <label for="telefono">Teléfono:</label>
+            <input  type="text"
+                    value={telefono}
+                    onChange={(e) => setTelefono(e.target.value)}
+                    required
+                    placeholder="Teléfono" />
+        </div>
+        <div class="form-group">
+            <label for="estado">Estado:</label>
+            <input  type="text"
+                    value={estado}
+                    onChange={(e) => setEstado(e.target.value)}
+                    required
+                    placeholder="Estado" />
+        </div>
+        <div class="form-group">
+            <label for="tipoPersonalId">Tipo Personal ID:</label>
+            <input type="text"
+                    value={tipoPersonalId}
+                    onChange={(e) => setTipoPersonalId(e.target.value)}
+                    required
+                    placeholder="ID del tipo de personal" />
+        </div>
+        <button type="submit" class="btn">Actualizar</button>
+    </form>
+    {/* Mostrar mensaje de éxito o error */}
+    {mensaje && <p>{mensaje}</p>}
+    
+</div>
+  );
+}
+
+export default ActualizarPersonal;

--- a/gest-ashoex-frontend/src/components/modificar/ActualizarPersonal.jsx
+++ b/gest-ashoex-frontend/src/components/modificar/ActualizarPersonal.jsx
@@ -1,7 +1,8 @@
+// src/components/ActualizarPersonal.jsx
+
 import React, { useState } from 'react';
-import axios from 'axios';
-import './ActualizarPersonal.css'; // Importa la hoja de estilos
-import fetchHealthStatus from '../../services/healthService.js';
+import './ActualizarPersonal.css';
+import { actualizarPersonal } from '../../services/ActualizarPersonalService';
 
 function ActualizarPersonal() {
   // Estados para almacenar los datos del formulario
@@ -14,7 +15,7 @@ function ActualizarPersonal() {
   const [mensaje, setMensaje] = useState('');
 
   // Función para manejar el envío del formulario
-  const handleSubmit = (event) => {
+  const handleSubmit = async (event) => {
     event.preventDefault();
 
     // Crear un objeto con los datos del formulario
@@ -26,77 +27,88 @@ function ActualizarPersonal() {
       tipo_personal_id: tipoPersonalId,
     };
 
-    // Hacer la solicitud PUT a la API de Laravel
-    axios
-      .put(`http://127.0.0.1:8000/api/personal-academico/${id}`, personalData)
-      .then((response) => {
-        setMensaje('Personal académico actualizado exitosamente.');
-        console.log('Respuesta del servidor:', response.data);
-      })
-      .catch((error) => {
-        setMensaje('Hubo un error al actualizar el personal académico.');
-        console.error('Error al hacer la solicitud:', error);
-      });
+    try {
+      // Llamar a la función del servicio para actualizar el personal
+      const response = await actualizarPersonal(id, personalData);
+      setMensaje('Personal académico actualizado exitosamente.');
+      console.log('Respuesta del servidor:', response);
+    } catch (error) {
+      setMensaje('Hubo un error al actualizar el personal académico.');
+      console.error('Error al hacer la solicitud:', error);
+    }
   };
 
   return (
-    <div class="container">
-    <h1>Actualizar Personal Académico</h1>
-    <form id="personal-form" onSubmit={handleSubmit}>
-        <div class="form-group">
-            <label for="id">ID:</label>
-            <input  type="text"
-                    value={id}
-                    onChange={(e) => setId(e.target.value)}
-                    required
-                    placeholder="ID del personal"/>
+    <div className="container">
+      <h1>Actualizar Personal Académico</h1>
+      <form id="personal-form" onSubmit={handleSubmit}>
+        {/* <div className="form-group">
+          <label htmlFor="id">ID:</label>
+          <input
+            type="text"
+            value={id}
+            onChange={(e) => setId(e.target.value)}
+            required
+            placeholder="ID del personal"
+          />
+        </div> */}
+        <div className="form-group">
+          <label htmlFor="name">Nombre:</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            placeholder="Nombre"
+          />
         </div>
-        <div class="form-group">
-            <label for="name">Nombre:</label>
-            <input  type="text"
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                    required
-                    placeholder="Nombre" />
+        <div className="form-group">
+          <label htmlFor="email">Email:</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            placeholder="Correo electrónico"
+          />
         </div>
-        <div class="form-group">
-            <label for="email">Email:</label>
-            <input  type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    required
-                    placeholder="Correo electrónico" />
+        <div className="form-group">
+          <label htmlFor="telefono">Teléfono:</label>
+          <input
+            type="text"
+            value={telefono}
+            onChange={(e) => setTelefono(e.target.value)}
+            required
+            placeholder="Teléfono"
+          />
         </div>
-        <div class="form-group">
-            <label for="telefono">Teléfono:</label>
-            <input  type="text"
-                    value={telefono}
-                    onChange={(e) => setTelefono(e.target.value)}
-                    required
-                    placeholder="Teléfono" />
+        <div className="form-group">
+          <label htmlFor="estado">Estado:</label>
+          <input
+            type="text"
+            value={estado}
+            onChange={(e) => setEstado(e.target.value)}
+            required
+            placeholder="Estado"
+          />
         </div>
-        <div class="form-group">
-            <label for="estado">Estado:</label>
-            <input  type="text"
-                    value={estado}
-                    onChange={(e) => setEstado(e.target.value)}
-                    required
-                    placeholder="Estado" />
+        <div className="form-group">
+          <label htmlFor="tipoPersonalId">Tipo Personal ID:</label>
+          <input
+            type="text"
+            value={tipoPersonalId}
+            onChange={(e) => setTipoPersonalId(e.target.value)}
+            required
+            placeholder="ID del tipo de personal"
+          />
         </div>
-        <div class="form-group">
-            <label for="tipoPersonalId">Tipo Personal ID:</label>
-            <input type="text"
-                    value={tipoPersonalId}
-                    onChange={(e) => setTipoPersonalId(e.target.value)}
-                    required
-                    placeholder="ID del tipo de personal" />
-        </div>
-        <button type="submit" class="btn">Actualizar</button>
-    </form>
-    {/* Mostrar mensaje de éxito o error */}
-    {mensaje && <p>{mensaje}</p>}
-    
-</div>
+        <button type="submit" className="btn">
+          Actualizar
+        </button>
+      </form>
+      {/* Mostrar mensaje de éxito o error */}
+      {mensaje && <p>{mensaje}</p>}
+    </div>
   );
 }
 

--- a/gest-ashoex-frontend/src/index.css
+++ b/gest-ashoex-frontend/src/index.css
@@ -1,4 +1,4 @@
-:root {
+/* :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
@@ -65,4 +65,4 @@ button:focus-visible {
   button {
     background-color: #f9f9f9;
   }
-}
+} */

--- a/gest-ashoex-frontend/src/pages/ActualizarPersonalPage.jsx
+++ b/gest-ashoex-frontend/src/pages/ActualizarPersonalPage.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import ActualizarPersonal from '../components/modificar/ActualizarPersonal.jsx';
+
+const ActualizarPersonalPage = () => {
+    return (
+        <div><ActualizarPersonal /></div>
+    );
+  };
+  
+  export default ActualizarPersonalPage;

--- a/gest-ashoex-frontend/src/services/ActualizarPersonalService.js
+++ b/gest-ashoex-frontend/src/services/ActualizarPersonalService.js
@@ -1,0 +1,23 @@
+// src/services/ActualizarPersonalService.js para la conexion put
+
+export const actualizarPersonal = async (id, personalData) => {
+    try {
+      const response = await fetch(`http://127.0.0.1:8000/api/personal-academico/${id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(personalData),
+      });
+  
+      if (!response.ok) {
+        throw new Error('Error en la solicitud al actualizar el personal académico.');
+      }
+  
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      throw new Error(error.message);
+    }
+  };
+  


### PR DESCRIPTION
**- ¿Qué es lo nuevo?**
Se implementó en el backend la funcionalidad para la actualización de los datos de tipo Personal Académico.
En el frontend, se realizo un formulario de edición para Personal Academico.

**- ¿Cómo se prueba?**
Desde la página de administración de Personal Académico en el frontend, editar un registro completando todos los datos de los campos.
Al guardar, el formulario enviará una solicitud PUT al backend con los datos actualizados, usando la ruta **/api/personal-academico/{id}**
Los campos del JSON usados son:
      {
        "name":"testing",
        "email":"test@test.com",
        "telefono": "60706070",
        "estado": "Activo",
        "tipo_personal_id":1
      }

**- Problemas conocidos**
Al realizar el registro se hizo de forma manual usando sentencia SQL, hizo falta crear un dato en la tabla Tipo Personal Academico para que funcione el registro.
