### PR TITLE
Actualizar personal académico y añadir unit tests

### DIFF
--- a/gest-ashoex-backend/app/Http/Controllers/PersonalAcademicoController.php
+++ b/gest-ashoex-backend/app/Http/Controllers/PersonalAcademicoController.php
@@ -61,20 +61,35 @@ class PersonalAcademicoController extends Controller
         }
     }
 
-    public function registrar(Request $request)
-    {
-        $personalAcademico = PersonalAcademico::create([
-            'nombre' => $request->name,
-            'email' => $request->email,
-            'telefono' => $request->telefono,
-            'estado' => $request->estado,
-            'tipo_personal_id' => $request->tipo_personal_id,
-        ]);
+    public function registrar(Request $request): JsonResponse
+    {   
+        $existingUser = PersonalAcademico::where('email', $request->email)->first();
+        
+        if ($existingUser) {
+            return response()->json([
+                'message' => 'El correo electrónico ya está en uso.',
+            ], 409);
+        }
+        try {
+            $personalAcademico = PersonalAcademico::create([
+                'nombre' => $request->name,
+                'email' => $request->email,
+                'telefono' => $request->telefono,
+                'estado' => $request->estado,
+                'tipo_personal_id' => $request->tipo_personal_id,
+            ]);
 
-        return response()->json([
-            'message' => 'Personal académico registrado exitosamente',
-            'personalAcademico' => $personalAcademico
-        ], 201);
+            return response()->json([
+                'message' => 'Personal académico registrado exitosamente',
+                'personalAcademico' => $personalAcademico
+            ], 201);
+
+        } catch (\Exception $e) {
+            return response()->json([
+                'message' => 'Error en el registro', 
+                'error' => $e->getMessage()
+            ], 500);
+        }
     }
 
     public function show($id)

--- a/gest-ashoex-backend/app/Http/Controllers/PersonalAcademicoController.php
+++ b/gest-ashoex-backend/app/Http/Controllers/PersonalAcademicoController.php
@@ -67,12 +67,18 @@ class PersonalAcademicoController extends Controller
         
         if ($existingUser) {
             return response()->json([
-                'message' => 'El correo electrónico ya está en uso.',
+                'success' => false,
+                'data' => null,
+                'error' => [
+                    'code' => 409,
+                    'message' => 'Conflicto'
+                ],
+                'message' => 'Datos de entrada inválidos, registro ya existente'
             ], 409);
         }
         try {
             $personalAcademico = PersonalAcademico::create([
-                'nombre' => $request->name,
+                'nombre' => $request->nombre,
                 'email' => $request->email,
                 'telefono' => $request->telefono,
                 'estado' => $request->estado,
@@ -80,14 +86,21 @@ class PersonalAcademicoController extends Controller
             ]);
 
             return response()->json([
-                'message' => 'Personal académico registrado exitosamente',
-                'personalAcademico' => $personalAcademico
+                'success'=> true,
+                'data' => $personalAcademico,
+                'error'=> null,
+                'message' => 'Personal academico registrado exitosamente',
             ], 201);
 
         } catch (\Exception $e) {
             return response()->json([
-                'message' => 'Error en el registro', 
-                'error' => $e->getMessage()
+                "success"=> false,
+                "data"=> null,
+                "error"=> [
+                    "code"=> 500,
+                    "message"=> "Error interno del servidor"
+                ],
+                "message"=> $e->getMessage()
             ], 500);
         }
     }

--- a/gest-ashoex-backend/database/factories/TipoPersonalFactory.php
+++ b/gest-ashoex-backend/database/factories/TipoPersonalFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\TipoPersonal;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\TipoPersonal>
+ */
+class TipoPersonalFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    protected $model = TipoPersonal::class;
+    public function definition()
+    {
+        return [
+            'nombre' => $this->faker->word(),
+        ];
+    }
+}

--- a/gest-ashoex-backend/routes/api.php
+++ b/gest-ashoex-backend/routes/api.php
@@ -16,7 +16,7 @@ Route::controller(PersonalAcademicoController::class)->group(function () {
 	Route::get('/personal-academicos/{id}', 'index');
     Route::get('/personal/{id}/informacion',  'show');
 
-    Route::post('/registrar-personal-academico', 'registrar');
+    Route::post('/personal-academico', 'registrar');
 
     Route::put('/personal-academico/{id}','update');
         

--- a/gest-ashoex-backend/tests/Feature/PersonalAcademicoTest.php
+++ b/gest-ashoex-backend/tests/Feature/PersonalAcademicoTest.php
@@ -61,6 +61,8 @@ class PersonalAcademicoTest extends TestCase
     /**
      * Test de registro de personal con email ya en uso
      */
+    
+    
     public function testRegistrarPersonalAcademicoEmailYaEnUso(): void
     {
         PersonalAcademico::factory()->create([
@@ -89,11 +91,12 @@ class PersonalAcademicoTest extends TestCase
             ]);
     }
 
-    /**
-     * Test de registro de personal correctamente
-     */
-    public function testRegistrarPersonalAcademicoExitoso(): void
+    public function testRegistrarPersonalAcademicoConExcepcion()
     {
+        $this->mock(PersonalAcademico::class, function ($mock) {
+            $mock->shouldReceive('create')->andReturn(null);
+        });
+        
         $tipoPersonal = TipoPersonal::factory()->create();
 
         $data = [
@@ -101,27 +104,12 @@ class PersonalAcademicoTest extends TestCase
             'email' => 'jane.doe@example.com',
             'telefono' => '+59171234568',
             'estado' => 'ACTIVO',
-            'tipo_personal_id' => $tipoPersonal->id
+            'tipo_personal_id' => 1
         ];
-
         $response = $this->postJson('/api/personal-academico', $data);
-
-        $response->assertStatus(201)
-            ->assertJson([
-                'success' => true,
-                'data' => [
-                    'nombre' => 'Jane Doe',
-                    'email' => 'jane.doe@example.com',
-                    'telefono' => '+59171234568',
-                    'estado' => 'ACTIVO',
-                    'tipo_personal_id' => $tipoPersonal->id,
-                    'id' => $response->json('data.id'),
-                ],
-                'error' => null,
-                'message' => 'Personal academico registrado exitosamente',
-            ]);
+        $response->assertStatus(500);
     }
-
+    
     /**
      * A basic feature test example.
      */

--- a/gest-ashoex-backend/tests/Feature/PersonalAcademicoTest.php
+++ b/gest-ashoex-backend/tests/Feature/PersonalAcademicoTest.php
@@ -30,7 +30,7 @@ class PersonalAcademicoTest extends TestCase
         $tipoPersonal = TipoPersonal::factory()->create();
 
         $data = [
-            'name' => 'John Doe',
+            'nombre' => 'John Doe',
             'email' => 'john.doe@example.com',
             'telefono' => '+59171234567',
             'estado' => 'ACTIVO',
@@ -41,7 +41,16 @@ class PersonalAcademicoTest extends TestCase
 
         $response->assertStatus(201)
             ->assertJson([
-                'message' => 'Personal académico registrado exitosamente',
+                'success' => true,
+                'data' => [
+                    'nombre' => 'John Doe',
+                    'email' => 'john.doe@example.com',
+                    'telefono' => '+59171234567',
+                    'estado' => 'ACTIVO',
+                    'tipo_personal_id' => $tipoPersonal->id,
+                ],
+                'error' => null,
+                'message' => 'Personal academico registrado exitosamente',
             ]);
 
         $this->assertDatabaseHas('personal_academicos', [
@@ -59,7 +68,7 @@ class PersonalAcademicoTest extends TestCase
         ]);
 
         $data = [
-            'name' => 'John Doe',
+            'nombre' => 'John Doe',
             'email' => 'john.doe@example.com',
             'telefono' => '+59171234567',
             'estado' => 'ACTIVO',
@@ -70,37 +79,46 @@ class PersonalAcademicoTest extends TestCase
 
         $response->assertStatus(409)
             ->assertJson([
-                'message' => 'El correo electrónico ya está en uso.',
+                'success' => false,
+                'data' => null,
+                'error' => [
+                    'code' => 409,
+                    'message' => 'Conflicto',
+                ],
+                'message' => 'Datos de entrada inválidos, registro ya existente',
             ]);
     }
 
     /**
-     * Test para manejar errores de registro.
+     * Test de registro de personal correctamente
      */
-    public function testRegistrarPersonalAcademicoErrorDeRegistro(): void
+    public function testRegistrarPersonalAcademicoExitoso(): void
     {
-        // Mock para simular una excepción durante el proceso de creación
-        $this->mock(PersonalAcademico::class, function ($mock) {
-            $mock->shouldReceive('create')
-                ->andThrow(new \Exception('Database error'));
-        });
-
         $tipoPersonal = TipoPersonal::factory()->create();
 
         $data = [
-            'name' => 'John Doe',
-            'email' => 'john.doe@example.com',
-            'telefono' => '+59171234567',
+            'nombre' => 'Jane Doe',
+            'email' => 'jane.doe@example.com',
+            'telefono' => '+59171234568',
             'estado' => 'ACTIVO',
-            'tipo_personal_id' => 9999
+            'tipo_personal_id' => $tipoPersonal->id
         ];
 
         $response = $this->postJson('/api/personal-academico', $data);
 
-        $response->assertStatus(500)
+        $response->assertStatus(201)
             ->assertJson([
-                'message' => 'Error en el registro',
-                // 'error' => 'Database error',
+                'success' => true,
+                'data' => [
+                    'nombre' => 'Jane Doe',
+                    'email' => 'jane.doe@example.com',
+                    'telefono' => '+59171234568',
+                    'estado' => 'ACTIVO',
+                    'tipo_personal_id' => $tipoPersonal->id,
+                    'id' => $response->json('data.id'),
+                ],
+                'error' => null,
+                'message' => 'Personal academico registrado exitosamente',
             ]);
     }
 


### PR DESCRIPTION
¿Qué es lo nuevo?
Se estandarizo los JSON y se añadió los try/catch para la función de registrar. Se añadió los siguientes unit tests:
- Para registrar personal académico con exitosamente
- Para registrar personal académico con email ya en uso
- Para registrar personal académico con excepción

Cambios en los archivos :
- PersonalAcademicoController.php
- PersonalAcademicoTest.php

¿Cómo se prueba?
- Para probar, el end point es http://127.0.0.1:8000/api/personal-academico, con json:
{
    "nombre": "Carlos Pérez",
    "email": "carlose@example.com",
    "telefono": "+59198765021",
    "estado": "ACTIVO",
    "tipo_personal_id": 1
}
- Para probar los unit tests ejecutar el comando `php artisan test`

Problemas conocidos
Sin problemas conocidos.