### PR TITLE
Modificar personal académico - Backend

### DIFF
--- a/gest-ashoex-backend/app/Http/Controllers/PersonalAcademicoController.php
+++ b/gest-ashoex-backend/app/Http/Controllers/PersonalAcademicoController.php
@@ -93,26 +93,74 @@ class PersonalAcademicoController extends Controller
     public function update(Request $request, $id)
     {
 
-        $personalAcademico = PersonalAcademico::find($id);
+        $personalAcademico = PersonalAcademico::with('tipoPersonal')->find($id);
 
         if (!$personalAcademico) {
             return response()->json([
-                'message' => 'Personal académico no encontrado.'
+                'success' => false,
+                'data' => null,
+                'error' => [
+                    'code' => 404,
+                    'message' => 'Personal académico no encontrado.'
+                ],
+                'message' => 'Error en la solicitud.'
             ], 404);
         }
 
-        $personalAcademico->nombre = $request->input('name');
-        $personalAcademico->email = $request->input('email');
-        $personalAcademico->telefono = $request->input('telefono');
-        $personalAcademico->estado = $request->input('estado');
-        $personalAcademico->tipo_personal_id = $request->input('tipo_personal_id');
+        $emailExistente = PersonalAcademico::where('email', $request->input('email'))->where('id', '!=', $id)->exists();
 
-        $personalAcademico->save();
+        if ($emailExistente) {
+            return response()->json([
+                'success' => false,
+                'data' => null,
+                'error' => [
+                    'code' => 400,
+                    'message' => 'El correo electrónico ya está registrado.'
+                ],
+                'message' => 'Error en la solicitud.'
+            ], 400);
+        }
 
-        return response()->json([
-            'message' => 'Personal académico actualizado exitosamente.',
-            'personal_academico' => $personalAcademico
-        ], 200);
+        try {
+
+            $request->validate([
+                'nombre' => 'required|string',
+                'email' => 'required|email',
+                'telefono' => 'required|string',
+                'estado' => 'required|string',
+                'tipo_personal_id' => 'required|integer|exists:tipo_personals,id'
+            ]);
+
+            $personalAcademico->nombre = $request->input('nombre');
+            $personalAcademico->email = $request->input('email');
+            $personalAcademico->telefono = $request->input('telefono');
+            $personalAcademico->estado = $request->input('estado');
+            $personalAcademico->tipo_personal_id = $request->input('tipo_personal_id');
+
+            $personalAcademico->save();
+
+            return response()->json([
+                'success' => true,
+                'data' => [
+                    'personal_academico' => $personalAcademico,
+                    'message' => 'Personal académico actualizado exitosamente.'
+                ],
+                'error' => null,
+                'message' => 'Operación exitosa.'
+            ], 200);
+
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'data' => null,
+                'error' => [
+                    'code' => 400,
+                    'message' => 'Datos de entrada inválidos.'
+                ],
+                'message' => 'Error en la solicitud.'
+            ], 400);
+        }
+
     }
 
 }

--- a/gest-ashoex-backend/app/Http/Controllers/PersonalAcademicoController.php
+++ b/gest-ashoex-backend/app/Http/Controllers/PersonalAcademicoController.php
@@ -141,10 +141,7 @@ class PersonalAcademicoController extends Controller
 
             return response()->json([
                 'success' => true,
-                'data' => [
-                    'personal_academico' => $personalAcademico,
-                    'message' => 'Personal académico actualizado exitosamente.'
-                ],
+                'data' => $personalAcademico,
                 'error' => null,
                 'message' => 'Operación exitosa.'
             ], 200);

--- a/gest-ashoex-backend/app/Http/Controllers/PersonalAcademicoController.php
+++ b/gest-ashoex-backend/app/Http/Controllers/PersonalAcademicoController.php
@@ -90,18 +90,130 @@ class PersonalAcademicoController extends Controller
         return response()->json($personalAcademico, 200);
     }
 
+    /**
+    * @OA\Put(
+    *     path="/api/personal-academico/{id}",
+    *     tags={"Personal Académico"},
+    *     summary="Actualiza un personal academico dado un id ",
+    *     description="Endpoint para actualizacion de personal académico.",
+    *     @OA\Parameter(
+    *         name="id",
+    *         in="path",
+    *         description="Id del personal académico",
+    *         required=true,
+    *         @OA\Schema(
+    *             type="integer"
+    *         )
+    *     ),
+    *     @OA\RequestBody(
+    *         request="Personal académico",
+    *         description="JSON con datos del personal académico",
+    *         required=true,
+    *         @OA\JSONContent(
+    *             type="object",
+    *             @OA\Property(property="nombre", type="string"),
+    *             @OA\Property(property="email", type="string"),
+    *             @OA\Property(property="telefono", type="string"),
+    *             @OA\Property(property="estado", type="integer"),
+    *             @OA\Property(property="tipo_personal_id", type="integer"),
+    *         )
+    *     ),
+    *     @OA\Response(
+    *         response=200,
+    *         description="Personal académico actualizado exitosamente",
+    *         @OA\JsonContent(
+    *             type="object",
+    *             @OA\Property(property="success", type="boolean", example=true),
+    *             @OA\Property(property="data", type="object",
+    *                  @OA\Property(property="nombre", type="string", example="Telly Denesik"),
+    *                  @OA\Property(property="email", type="string", example="cecelia73@example.org"),
+    *                  @OA\Property(property="telefono", type="string", example="+59182433091"),
+    *                  @OA\Property(property="estado", type="string", example="ACTIVO"),
+    *                  @OA\Property(property="tipo_personal_id", type="integer", example="1"),
+    *              ),
+    *             @OA\Property(property="error", type="array",
+    *                  @OA\Items(type="object"),
+    *                  example="null"
+    *              ),
+    *             @OA\Property(property="message", type="string", example="Operacion exitosa.")
+    *         )
+    *     ),
+    *     @OA\Response(
+    *         response=404,
+    *         description="Id de personal académico ingresada inexistente en base de datos.",
+    *         @OA\JsonContent(
+    *             type="object",
+    *             @OA\Property(property="success", type="boolean", example=false),
+    *             @OA\Property(property="data", type="array",
+    *                  @OA\Items(type="object"),
+    *                  example="null"
+    *              ),
+    *             @OA\Property(property="error", type="array",
+    *                  @OA\Items(
+    *                      type="object",
+    *                      @OA\Property(property="code", type="integer", example="404"),
+    *                      @OA\Property(property="message", type="string", example="Personal académico no encontrado.")
+    *                      )
+    *                  ),
+    *             @OA\Property(property="message", type="string", example="Error en la solicitud.")
+    *         )
+    *     ),
+    *     @OA\Response(
+    *         response=409,
+    *         description="Correo electrónico previamente registrado.",
+    *         @OA\JsonContent(
+    *             type="object",
+    *             @OA\Property(property="success", type="boolean", example=false),
+    *             @OA\Property(property="data", type="array",
+    *                  @OA\Items(type="object"),
+    *                  example="null"
+    *              ),
+    *             @OA\Property(property="error", type="array",
+    *                  @OA\Items(
+    *                      type="object",
+    *                      @OA\Property(property="code", type="integer", example="409"),
+    *                      @OA\Property(property="message", type="string", example="El correo electrónico ya está registrado.")
+    *                      )
+    *                  ),
+    *             @OA\Property(property="message", type="string", example="Error en la solicitud.")
+    *         )
+    *     ),
+    *     @OA\Response(
+    *         response=400,
+    *         description="Error de validacion en algun campo del json recibido.",
+    *         @OA\JsonContent(
+    *             type="object",
+    *             @OA\Property(property="success", type="boolean", example=false),
+    *             @OA\Property(property="data", type="array",
+    *                  @OA\Items(type="object"),
+    *                  example="null"
+    *              ),
+    *             @OA\Property(property="error", type="array",
+    *                  @OA\Items(
+    *                      type="object",
+    *                      @OA\Property(property="code", type="integer", example="400"),
+    *                      @OA\Property(property="message", type="string", example="Datos de entrada inválidos.")
+    *                      )
+    *                  ),
+    *             @OA\Property(property="message", type="string", example="Error en la solicitud.")
+    *         )
+    *     ),
+    * )
+    */
     public function update(Request $request, $id)
     {
 
-        $personalAcademico = PersonalAcademico::with('tipoPersonal')->find($id);
+        $personalAcademico = PersonalAcademico::find($id);
 
         if (!$personalAcademico) {
             return response()->json([
                 'success' => false,
                 'data' => null,
                 'error' => [
-                    'code' => 404,
-                    'message' => 'Personal académico no encontrado.'
+                    [
+                        'code' => 404,
+                        'message' => 'Personal académico no encontrado.'
+                    ]
                 ],
                 'message' => 'Error en la solicitud.'
             ], 404);
@@ -114,11 +226,13 @@ class PersonalAcademicoController extends Controller
                 'success' => false,
                 'data' => null,
                 'error' => [
-                    'code' => 400,
-                    'message' => 'El correo electrónico ya está registrado.'
+                    [
+                        'code' => 409,
+                        'message' => 'El correo electrónico ya está registrado.'
+                    ]
                 ],
                 'message' => 'Error en la solicitud.'
-            ], 400);
+            ], 409);
         }
 
         try {
@@ -151,8 +265,10 @@ class PersonalAcademicoController extends Controller
                 'success' => false,
                 'data' => null,
                 'error' => [
-                    'code' => 400,
-                    'message' => 'Datos de entrada inválidos.'
+                    [
+                        'code' => 400,
+                        'message' => 'Datos de entrada inválidos.'
+                    ]
                 ],
                 'message' => 'Error en la solicitud.'
             ], 400);

--- a/gest-ashoex-backend/storage/api-docs/api-docs.json
+++ b/gest-ashoex-backend/storage/api-docs/api-docs.json
@@ -44,12 +44,248 @@
                     }
                 }
             }
+        },
+        "/api/personal-academico/{id}": {
+            "put": {
+                "tags": [
+                    "Personal Académico"
+                ],
+                "summary": "Actualiza un personal academico dado un id ",
+                "description": "Endpoint para actualizacion de personal académico.",
+                "operationId": "97169f518c2c30789d0bc64a809b9fd2",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Id del personal académico",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "JSON con datos del personal académico",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "nombre": {
+                                        "type": "string"
+                                    },
+                                    "email": {
+                                        "type": "string"
+                                    },
+                                    "telefono": {
+                                        "type": "string"
+                                    },
+                                    "estado": {
+                                        "type": "integer"
+                                    },
+                                    "tipo_personal_id": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Personal académico actualizado exitosamente",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "nombre": {
+                                                    "type": "string",
+                                                    "example": "Telly Denesik"
+                                                },
+                                                "email": {
+                                                    "type": "string",
+                                                    "example": "cecelia73@example.org"
+                                                },
+                                                "telefono": {
+                                                    "type": "string",
+                                                    "example": "+59182433091"
+                                                },
+                                                "estado": {
+                                                    "type": "string",
+                                                    "example": "ACTIVO"
+                                                },
+                                                "tipo_personal_id": {
+                                                    "type": "integer",
+                                                    "example": "1"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "error": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "example": "null"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Operacion exitosa."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Id de personal académico ingresada inexistente en base de datos.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "example": "null"
+                                        },
+                                        "error": {
+                                            "type": "array",
+                                            "items": {
+                                                "properties": {
+                                                    "code": {
+                                                        "type": "integer",
+                                                        "example": "404"
+                                                    },
+                                                    "message": {
+                                                        "type": "string",
+                                                        "example": "Personal académico no encontrado."
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Error en la solicitud."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Correo electrónico previamente registrado.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "example": "null"
+                                        },
+                                        "error": {
+                                            "type": "array",
+                                            "items": {
+                                                "properties": {
+                                                    "code": {
+                                                        "type": "integer",
+                                                        "example": "409"
+                                                    },
+                                                    "message": {
+                                                        "type": "string",
+                                                        "example": "El correo electrónico ya está registrado."
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Error en la solicitud."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error de validacion en algun campo del json recibido.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "example": "null"
+                                        },
+                                        "error": {
+                                            "type": "array",
+                                            "items": {
+                                                "properties": {
+                                                    "code": {
+                                                        "type": "integer",
+                                                        "example": "400"
+                                                    },
+                                                    "message": {
+                                                        "type": "string",
+                                                        "example": "Datos de entrada inválidos."
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Error en la solicitud."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "tags": [
         {
             "name": "Health Check",
             "description": "Health Check"
+        },
+        {
+            "name": "Personal Académico",
+            "description": "Personal Académico"
         }
     ]
 }


### PR DESCRIPTION
- ¿Qué es lo nuevo?
Se realizo el manejo de errores, devolviendo respuestas JSON personalizadas según el formato acordado para el caso de validaciones para asegurar que los datos de entrada sean correctos y que el email no esté duplicado, así como la verificación de que el tipo de personal existe en la base de datos.
Se realizo la documentacion respectiva del endpoint usando Swagger y OpenApi

- ¿Cómo se prueba?
Para probar la funcionalidad, se debe enviar una solicitud PUT al backend con los datos actualizados a través de la ruta /api/personal-academico/{id}. Los campos del JSON utilizados son:
{
  "nombre": "Nombre Ejemplo",
  "email": "ejemplo@test.com",
  "telefono": "60706070",
  "estado": "Activo",
  "tipo_personal_id": 1
}
Para revisar la documentacion se ingresa al enlace:
http://localhost:8000/api/documentation

- Problemas conocidos
La response en caso de datos incorrectos aun no está integrada con las validaciones por campo mencionadas en telegram.