### PR TITLE
Modificar personal academico - Validaciones con FormRequest

### DIFF
--- a/gest-ashoex-backend/app/Exceptions/PersonalAcademicoNotFoundException.php
+++ b/gest-ashoex-backend/app/Exceptions/PersonalAcademicoNotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class PersonalAcademicoNotFoundException extends Exception
+{
+    public function render()
+    {
+        return response()->json([
+            'success' => false,
+            'data' => null,
+            'error' => [
+                'status' => 404,
+                'detail' => "Personal académico con ese ID no encontrado.",
+            ],
+            'message' => 'Error en la solicitud.'
+        ], 404);
+    }
+}

--- a/gest-ashoex-backend/app/Http/Controllers/PersonalAcademicoController.php
+++ b/gest-ashoex-backend/app/Http/Controllers/PersonalAcademicoController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 
 use App\Models\PersonalAcademico;
+use App\Http\Requests\ActualizarPersonalRequest;
 use Exception;
 
 class PersonalAcademicoController extends Controller
@@ -184,75 +185,24 @@ class PersonalAcademicoController extends Controller
         }
     }
 
-    public function update(Request $request, $id)
+    public function update(ActualizarPersonalRequest $request, $id)
     {
 
-        $personalAcademico = PersonalAcademico::find($id);
+        $personalAcademico = PersonalAcademico::with('tipoPersonal')->findOrFail($id);
 
-        if (!$personalAcademico) {
-            return response()->json([
-                'success' => false,
-                'data' => null,
-                'error' => [
-                    'code' => 404,
-                    'message' => 'Personal académico no encontrado.'
-                ],
-                'message' => 'Error en la solicitud.'
-            ], 404);
-        }
+        $personalAcademico->update($request->validated());
 
-        $emailExistente = PersonalAcademico::where('email', $request->input('email'))->where('id', '!=', $id)->exists();
+        $personalAcademico->load('tipoPersonal');
 
-        if ($emailExistente) {
-            return response()->json([
-                'success' => false,
-                'data' => null,
-                'error' => [
-                    'code' => 409,
-                    'message' => 'El correo electrónico ya está registrado.'
-                ],
-                'message' => 'Error en la solicitud.'
-            ], 409);
-        }
-
-        try {
-
-            $request->validate([
-                'nombre' => 'required|string',
-                'email' => 'required|email',
-                'telefono' => 'required|string',
-                'estado' => 'required|string',
-                'tipo_personal_id' => 'required|integer|exists:tipo_personals,id'
-            ]);
-
-            $personalAcademico->nombre = $request->input('nombre');
-            $personalAcademico->email = $request->input('email');
-            $personalAcademico->telefono = $request->input('telefono');
-            $personalAcademico->estado = $request->input('estado');
-            $personalAcademico->tipo_personal_id = $request->input('tipo_personal_id');
-
-            $personalAcademico->save();
-
-            return response()->json([
-                'success' => true,
-                'data' => $personalAcademico,
-                'error' => null,
-                'message' => 'Operación exitosa.'
-            ], 200);
-
-        } catch (\Exception $e) {
-            return response()->json([
-                'success' => false,
-                'data' => null,
-                'error' => [
-                    'code' => 400,
-                    'message' => 'Datos de entrada inválidos.'
-                ],
-                'message' => 'Error en la solicitud.'
-            ], 400);
-        }
+        return response()->json([
+            'success' => true,
+            'data' => $personalAcademico,
+            'error' => null,
+            'message' => 'Operación exitosa.'
+        ], 200);
 
     }
+
     public function test_obtener_lista_de_personal_academico_exitosamente()
     {
         // Se inserta datos en la tabla

--- a/gest-ashoex-backend/app/Http/Requests/ActualizarPersonalRequest.php
+++ b/gest-ashoex-backend/app/Http/Requests/ActualizarPersonalRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Exceptions\PersonalAcademicoNotFoundException;
+use App\Models\PersonalAcademico;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ActualizarPersonalRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'nombre' => 'required|string|max:100',
+            'email' => 'required|email|unique:personal_academicos,email,' . $this->route('id'),
+            'telefono' => 'required|string|max:20',
+            'estado' => 'required|string|in:ACTIVO,DESPEDIDO',
+            'tipo_personal_id' => 'required|integer|exists:tipo_personals,id'
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $id = $this->route('id');
+
+        if (!PersonalAcademico::where('id', $id)->exists()) {
+            throw new PersonalAcademicoNotFoundException();
+        }
+    }
+
+}


### PR DESCRIPTION
**- ¿Qué es lo nuevo?**
Se realizo la validacion de los campos recibidos usando FormRequest y Exception para el caso especifico de inexistencia de personal dado un id.

**- ¿Cómo se prueba?**
Enviar una solicitud PUT al backend con los datos actualizados a través de la ruta /api/personal-academico/{id}. Los campos del JSON utilizados son:
{
  "nombre": "Nombre Ejemplo",
  "email": "ejemplo@test.com",
  "telefono": "60706070",
  "estado": "Activo",
  "tipo_personal_id": 1
}

**- Problemas conocidos**
